### PR TITLE
chat mode template & tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+__pycache__/

--- a/ChatGPT3.py
+++ b/ChatGPT3.py
@@ -1,0 +1,37 @@
+import logging
+import os
+import openai
+
+
+class ChatGPT3(object):
+    """
+    The aim of ChatGPT3 is to imitate ChatGPT's functionality with GPT-3 API, though conversations must be brief due
+    to the 4000 token constraint for Text-Davinci-003.
+    Author Credits: OpenAI
+    """
+    def __init__(self, config=None):
+        if config is None:
+            config = {"model": "text-davinci-003",
+                      "context": ""}
+        self.openai_api_key = os.environ.get('OPENAI_API_KEY')
+        self.model = config['model']
+        self.context = config['context']
+
+    def get_response(self, text):
+        openai.api_key = self.openai_api_key
+        response = openai.Completion.create(
+            engine="text-davinci-003",
+            prompt=text,
+            temperature=0.7,
+            max_tokens=4000,
+            top_p=0.9,
+            frequency_penalty=1,
+            presence_penalty=0
+        )
+        return response['choices'][0]['text']
+
+    def chat(self, text):
+        response = self.get_response(self.context + text)
+        self.context += text + "\n"
+        logging.info(response)
+        return response

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# ChatGPT3
+The aim of ChatGPT3 is to imitate ChatGPT's functionality with GPT-3 API, though conversations must be brief due to the 4000 token constraint for Text-Davinci-003.
+
+# Setup
+1. Get key from https://platform.openai.com/account/api-keys
+2. Create environment variable `OPENAI_API_KEY`
+3. refer to `tests.py` for usage.
+
+# Tests
+passing
+
+```
+Launching unittests with arguments python -m unittest tests.TestChatGPT3 in C:\Users\stanc\PycharmProjects\ChatGPT3
+1. Bootstrap
+2. Foundation
+3. AngularJS
+4. ReactJS
+5. VueJS 
+6. Semantic UI 
+7. Bulma 
+8. Materialize CSS 
+9. TailwindCSS 
+10 .PureCSS
+
+INFO:root:
+1. Bootstrap 
+2. Angular 
+3. React 
+4. Vue 
+5. Foundation 
+6. Semantic UI  
+7. Bulma  
+8. Materialize  
+9. Tailwind CSS  
+10. Svelte  
+
+For beginners, the best frameworks are Bootstrap, Foundation, and Materialize as they are easy to learn and have comprehensive documentation and tutorials available online for free or at low cost
+
+Ran 2 tests in 16.062s
+
+OK
+Process finished with exit code 0
+```

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,29 @@
+import logging
+from unittest import TestCase
+
+from ChatGPT3 import ChatGPT3
+
+logging.basicConfig(level=logging.INFO)
+
+
+class TestChatGPT3(TestCase):
+    """
+    Author: stan.chen@plusgpt.app
+    """
+    def test_get_response(self):
+        config = {"model": "text-davinci-003",
+                  "context": ""}
+        convo = ChatGPT3(config=config)
+        data = convo.get_response("What are 10 frontend frameworks?")
+        logging.info(data)
+        assert data is not None
+
+    def test_chat(self):
+        config = {"model": "text-davinci-003",
+                  "context": ""}
+        convo = ChatGPT3(config=config)
+        data = convo.chat("What are 10 frontend frameworks?")
+        logging.info(data)
+        data = convo.chat("which of the frameworks are best for beginners?")
+        logging.info(data)
+        assert data is not None


### PR DESCRIPTION
GPT-3 is quite limited to be used as a conversation mode yet, but we can get it working as it right now while waiting for the official chatgpt api

# Tests
passing

```
Launching unittests with arguments python -m unittest tests.TestChatGPT3 in C:\Users\stanc\PycharmProjects\ChatGPT3
1. Bootstrap
2. Foundation
3. AngularJS
4. ReactJS
5. VueJS 
6. Semantic UI 
7. Bulma 
8. Materialize CSS 
9. TailwindCSS 
10 .PureCSS

INFO:root:
1. Bootstrap 
2. Angular 
3. React 
4. Vue 
5. Foundation 
6. Semantic UI  
7. Bulma  
8. Materialize  
9. Tailwind CSS  
10. Svelte  

For beginners, the best frameworks are Bootstrap, Foundation, and Materialize as they are easy to learn and have comprehensive documentation and tutorials available online for free or at low cost

Ran 2 tests in 16.062s

OK
Process finished with exit code 0
```